### PR TITLE
Misc Windows fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+.idea/
 
 # Icon must end with two \r
 # Icon
@@ -25,3 +26,8 @@
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Project related
+*.exe
+*.json
+*.mmdb

--- a/app/main_proxy.go
+++ b/app/main_proxy.go
@@ -58,7 +58,9 @@ func (s *fakeListener) Close() error {
 	case <-s.closed:
 		return nil
 	default:
-		close(s.closed)
+		if s.closed != nil {
+			close(s.closed)
+		}
 	}
 	return nil
 }

--- a/device/windivert/device.go
+++ b/device/windivert/device.go
@@ -96,11 +96,11 @@ func NewDevice(filter string) (dev *Device, err error) {
 		event:     make(chan struct{}, 1),
 	}
 
-	go dev.writeLoop()
-
 	nw := dev.Address.Network()
 	nw.InterfaceIndex = ifIdx
 	nw.SubInterfaceIndex = subIfIdx
+
+	go dev.writeLoop()
 
 	return
 }

--- a/protocol/trojan/handler.go
+++ b/protocol/trojan/handler.go
@@ -213,7 +213,9 @@ func NewHandler(url string, timeout time.Duration) (*Handler, error) {
 }
 
 func (h *Handler) Close() error {
-	h.ticker.Stop()
+	if h.ticker != nil {
+		h.ticker.Stop()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Hi, @imgk, When I build shadow in my Windows box, I encountered several errors.
I attempted to patch them, I hope I did the right things.

Here is my sample config:
```json
{
    "server": "trojan://xxx@IP:PORT#DOMAIN",
    "name_server": "https://162.159.46.1/dns-query",
    "geo_ip_rules": {
        "file": "GeoLite2-ASN.mmdb",
        "proxy": [],
        "bypass": [
            "zh-CN"
        ],
        "final": "proxy"
    },
    "windivert_filter_string": "outbound && ip.DstAddr != 162.159.46.1 && ip.DstAddr != IP"
}
```

`protocol/trojan/handler.go: Fix potential nil pointer dereference`:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x13356b5]

goroutine 1 [running]:
time.(*Ticker).Stop(...)
        c:/go/src/time/tick.go:46
github.com/imgk/shadow/protocol/trojan.(*Handler).Close(0xc0000e0000, 0x0, 0x0)
        C:/Users/lei/Desktop/stage/shadow/protocol/trojan/handler.go:216 +0x55
github.com/imgk/shadow/app.(*App).Run.func1(0xc000135d88, 0xc0000cc000)
        C:/Users/lei/Desktop/stage/shadow/app/main_win.go:36 +0xc6
github.com/imgk/shadow/app.(*App).Run(0xc0000cc000, 0x185a240, 0xc000306150)
        C:/Users/lei/Desktop/stage/shadow/app/main_win.go:75 +0x11d6
main.main()
        C:/Users/lei/Desktop/stage/shadow/main.go:41 +0x3b6
```

`device/windivert/device.go: Fix DATA RACE in device.NewDevice()`
```
PS C:\Users\lei\Desktop\stage\shadow> sudo .\shadow.exe -v
shadow - a transparent proxy for Windows, Linux and macOS
shadow is running...
==================
WARNING: DATA RACE
Read at 0x00c00023c1a0 by goroutine 12:
  github.com/imgk/shadow/device/windivert.(*Device).writeLoop()
      C:/Users/lei/Desktop/stage/shadow/device/windivert/device.go:479 +0x157

Previous write at 0x00c00023c1a0 by main goroutine:
  github.com/imgk/shadow/device/windivert.NewDevice()
      C:/Users/lei/Desktop/stage/shadow/device/windivert/device.go:102 +0xd19
  github.com/imgk/shadow/app.(*App).Run()
      C:/Users/lei/Desktop/stage/shadow/app/main_win.go:66 +0xa64
  main.main()
      C:/Users/lei/Desktop/stage/shadow/main.go:41 +0x3b5

Goroutine 12 (running) created at:
  github.com/imgk/shadow/device/windivert.NewDevice()
      C:/Users/lei/Desktop/stage/shadow/device/windivert/device.go:99 +0xcad
  github.com/imgk/shadow/app.(*App).Run()
      C:/Users/lei/Desktop/stage/shadow/app/main_win.go:66 +0xa64
  main.main()
      C:/Users/lei/Desktop/stage/shadow/main.go:41 +0x3b5
==================
```

`app/main_proxy.go: Fix potential close of nil channel`
```
PS C:\Users\lei\Desktop\stage\shadow> sudo .\shadow.exe -v
shadow - a transparent proxy for Windows, Linux and macOS
shadow is running...
shadow is closing...
panic: close of nil channel

goroutine 1 [running]:
github.com/imgk/shadow/app.(*fakeListener).Close(0xc000028420, 0x0, 0xc000200800)
        C:/Users/lei/Desktop/stage/shadow/app/main_proxy.go:61 +0xa5
github.com/imgk/shadow/app.(*proxyServer).Close(0xc0000283f8, 0xc000226060, 0x0)
        C:/Users/lei/Desktop/stage/shadow/app/main_proxy.go:180 +0xa5
github.com/imgk/shadow/app.(*App).Close(0xc0000282c0)
        C:/Users/lei/Desktop/stage/shadow/app/main.go:148 +0xb3
main.main()
        C:/Users/lei/Desktop/stage/shadow/main.go:52 +0x68a
```