### PR TITLE
main.go: Don't capture os.Kill signal.

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	fmt.Println("shadow - a transparent proxy for Windows, Linux and macOS")
 	fmt.Println("shadow is running...")
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, os.Kill)
+	signal.Notify(sigCh, os.Interrupt)
 	<-sigCh
 	fmt.Println("shadow is closing...")
 


### PR DESCRIPTION
`os.Kill` can't be caught or ignored in Windows/*nix.
I have no doubt in Linux/macOS.
After I tested, Windows cannot capture `os.Kill` neither.

Please confirm this fix. @imgk 